### PR TITLE
Fix replacing language token with correct amr_XX token

### DIFF
--- a/src/mbart_amr/data/dataset.py
+++ b/src/mbart_amr/data/dataset.py
@@ -65,10 +65,7 @@ def collate_amr(
     )
     labels = tokenizer.encode_penmanstrs(
         [s["penmanstr"] for s in samples],
-        padding=True,
-        truncation=True,
         max_length=output_max_seq_length,
-        return_tensors="pt",
     ).input_ids
     labels = torch.where(labels == tokenizer.pad_token_id, -100, labels)
 


### PR DESCRIPTION
There was an issue (closes #3) where tokenization for the target side (i.e. the AMR side) would not correctly add an amr_XX language token.

Just adding amr_XX to voc and defining it in the tokenizer as the tgt_lang is not enough because we are always just calling the tokenizer (as if it were the source tokenizer). However, we cannot even use the tokenizer as a "target tokenizer" (special tokenizer mode) with tgt_lang amr_XX, because the MBARTTokenizer only allows special language codes as tgt_lang for this purpose so we cannot take that approach. Instead we will be replacing the special source language token in "encode_penmanstrs" with our own, amr_XX one.

Minimal example that correctly shows the amr_XX token, and that also shows that this works when padding tokens are present:

```python
from mbart_amr.data.tokenization import AMRMBartTokenizer

penman_str1 = """(n / need-01
      :ARG0 (w / we)
      :ARG1 (w2 / water
            :purpose (d / drink-01
                        :ARG0 w
                        :ARG1 w2)))"""
penman_str2 = """(n / need
      :ARG0 (w / we))"""

if __name__ == '__main__':
    tokenizer = AMRMBartTokenizer.from_pretrained("facebook/mbart-large-cc25")

    tokenized = tokenizer.encode_penmanstrs([penman_str1, penman_str2])
    print(tokenized)
    print(tokenizer.decode(tokenized["input_ids"][0]))
    print(tokenizer.decode(tokenized["input_ids"][1]))

    print(tokenizer.decode_and_fix(tokenized["input_ids"][0]))
    print(tokenizer.decode_and_fix(tokenized["input_ids"][1]))
```